### PR TITLE
start both Metadata-API and PiGallery2 in start.sh

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -14,9 +14,6 @@ COPY ./exifapi /exifapi
 # make start script runnable
 RUN chmod +x /exifapi/start.sh
 
-# start Metadata-API
-CMD ["/exifapi/start.sh"]
-
-# start PiGallery2
-ENTRYPOINT ["node", "./src/backend/index", "--expose-gc",  "--config-path=/app/data/config/config.json"]
+# start both Metadata-API and PiGallery2
+ENTRYPOINT ["/exifapi/start.sh"]
 

--- a/src/exifapi/start.sh
+++ b/src/exifapi/start.sh
@@ -14,3 +14,8 @@ if kill -0 $FLASK_PID 2>/dev/null; then
 else
   echo "❌ Error: Metadata-API could not be started."
 fi
+
+# Start PiGallery2
+cd /app
+echo "Start PiGallery2..."
+exec node ./src/backend/index.js --expose-gc --config-path="/app/data/config/config.json"


### PR DESCRIPTION
we need to start both Metadata-API and PiGallery2 in `start.sh` because `CMD` followed by `ENTRYPOINT` in the Dockerfile will only execute the last one.