### PR TITLE
add support for search or album

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,12 +94,12 @@ Click this bookmark while viewing a specific photo or video in PiGallery2 to ope
 ```javascript
 javascript:(function(){
   const p = new URL(window.location.href);
-  if (p.pathname.includes('/gallery')) {
+  if (p.pathname.includes('/gallery') || p.pathname.includes('/search')) {
     const base = p.origin.replace(/:\d+$/, ':<METADATA_API_PORT>');
     const target = base + '/meta/index.html?img=' + encodeURIComponent(p.href);
     window.open(target, '_blank');
   } else {
-    alert('Not a PiGallery2 image page');
+    alert('Not a PiGallery2 image, search or album page');
   }
 })();
 ```

--- a/src/exifapi/ui/script.js
+++ b/src/exifapi/ui/script.js
@@ -147,14 +147,15 @@ window.addEventListener("DOMContentLoaded", async () => {
 
 function convertGalleryUrlToPath(urlString) {
   const parsed = new URL(urlString);
-  const galleryMatch = parsed.pathname.match(/\/gallery\/(.+)/);
   const filename = parsed.searchParams.get("p");
 
-  if (!galleryMatch || !filename) {
-    throw new Error("Invalid PiGallery2 URL");
-  }
+  if (!filename) throw new Error("Invalid PiGallery2 URL");
 
-  const decodedDir = decodeURIComponent(galleryMatch[1]);
-  return `/app/data/images/${decodedDir}/${filename}`;
+  // If it is a gallery URL, we extract the directory path from the URL
+  const decodedDir = parsed.pathname.includes('/gallery')
+      ? decodeURIComponent(parsed.pathname.match(/\/gallery\/(.+)/)[1])
+      : ''; // No extra directory for search
+
+  return `/app/data/images/${decodedDir ? decodedDir + '/' : ''}${filename}`;
 }
 


### PR DESCRIPTION
With this PR we can also use PiGallery2 URLs from a search or album page. Before it was limited gallery page URLs.